### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -23,7 +23,7 @@ $(document).on('turbolinks:load', function(){
     grandchildSelectHtml = `<div class='category--box__added' id= 'grandchildren_wrapper'>
                               <div class='select--wrap__box'>
                                 <select class="select--wrap__box--select" id="grandchild_category" name="product[category_id]">
-                                  <option value="---" data-category="---">---</option>
+                                  <option value="---" data-category="---"selected>---</option>
                                   ${insertHTML}
                                 </select>
                               </div>

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -43,6 +43,8 @@ $(document).on('turbolinks:load', function(){
       .done(function(children){
         $('#children_wrapper').remove(); //親が変更された時、子以下を削除する
         $('#grandchildren_wrapper').remove();
+        $('#grandchildren').remove();
+        $('#children').remove();
         var insertHTML = '';
         children.forEach(function(child){
           insertHTML += appendOption(child);
@@ -55,6 +57,8 @@ $(document).on('turbolinks:load', function(){
     }else{
       $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除する
       $('#grandchildren_wrapper').remove();
+      $('#grandchildren').remove();
+      $('#children').remove();
     }
   });
   $('.category').on('change', '#child_category', function(){
@@ -69,6 +73,7 @@ $(document).on('turbolinks:load', function(){
       .done(function(grandchildren){
         if (grandchildren.length != 0) {
           $('#grandchildren_wrapper').remove(); //子が変更された時、孫以下を削除するする
+          $('#grandchildren').remove();
           var insertHTML = '';
           grandchildren.forEach(function(grandchild){
             insertHTML += appendOption(grandchild);
@@ -81,6 +86,7 @@ $(document).on('turbolinks:load', function(){
       })
     }else{
       $('#grandchildren_wrapper').remove(); //子カテゴリーが初期値になった時、孫以下を削除する
+      $('#grandchildren').remove();
     }
   });
 });

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,7 +25,7 @@ class ProductsController < ApplicationController
 
   def create
     @product = Product.new(product_params)
-    if @product.save
+    if @product.save!
       redirect_to root_path
     else
       render '/products/new'
@@ -44,9 +44,10 @@ class ProductsController < ApplicationController
   end
   
   def edit
-    @grandchildren = Category.find(@product.category_id)
-    @children = @grandchildren.parent
-    @parent = @grandchildren.parent.parent
+     # productに紐づいていいる孫カテゴリーの親である子カテゴリが属している子カテゴリーの一覧を配列で取得
+    @category_child_array = @product.category.parent.parent.children
+     # productに紐づいていいる孫カテゴリーが属している孫カテゴリーの一覧を配列で取得
+    @category_grandchild_array = @product.category.parent.children
   end
 
   def update

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,7 +6,7 @@ class Product < ApplicationRecord
   belongs_to :category
   belongs_to :user
   has_many :comments
-  belongs_to :buyer, class_name: "User"
+  belongs_to :buyer, class_name: "User", optional: true
   has_many :images
   accepts_nested_attributes_for :images, allow_destroy: true
   validates :price, numericality: :only_integer, presence: true

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -4,28 +4,23 @@
     .sell--contents
       .contents--title
         商品の情報を入力
-
       .sell-form-container
         .sell-form-container__label
-
           出品画像
           %span.form_require
             必須
         .images--info
-
           最大5枚までアップロードできます
-        = f.fields_for :images do |image|
-          .dropzone-container.clearfix
-            #preview
-            .dropzone-area
-              = image.label :image, class: "dropzone-box", for: "upload-image" do
-                %p
-                  ドラッグ＆ドロップ
-                  %br
-                  またはクリックしてファイルをアップロード
-                .input_area
-                  = image.file_field :image, id: "upload-image", class: "upload-image", 'data-image': 0
-
+          = f.fields_for :images do |i|
+            .dropzone-container.clearfix
+              #preview
+              .dropzone-area
+                = i.label :image, class: "dropzone-box", for: "upload-image" do
+                  .input_area
+                    = i.file_field :image, multiple: true, name: 'product[images_attributes][][image]', id: "upload-image", class: "upload-image", 'data-image': 0
+                    %pre.dropzone-area__text
+                      ドラッグ&ドロップ
+                      またはクリックしてファイルをアップロード
       .products--name
         .products--name--title
           商品名
@@ -51,7 +46,12 @@
                 必須
             .category--box
               .select--wrap__box
-                = f.select :category_id, @category_parent_array, {:prompt => "---"}, {class: 'select--wrap__box--select', id: 'parent_category', name: ''}
+                = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @product.category.parent.parent.name), {}, {class: 'select', id: 'parent_category'}
+              .form_group#children
+                = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.parent.id), {}, {class: 'select', id: 'child_category'}
+              .form_group#grandchildren
+                = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.id), {}, {class: 'select', id: 'grandchild_category'}
+              = f.text_field :category_id, id: 'grand_child_result_id', type: 'hidden'
           .brand
             .brand--title
               ブランド

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -46,12 +46,11 @@
                 必須
             .category--box
               .select--wrap__box
-                = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @product.category.parent.parent.name), {}, {class: 'select', id: 'parent_category'}
-              .form_group#children
-                = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.parent.id), {}, {class: 'select', id: 'child_category'}
-              .form_group#grandchildren
-                = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.id), {}, {class: 'select', id: 'grandchild_category'}
-              = f.text_field :category_id, id: 'grand_child_result_id', type: 'hidden'
+                = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @product.category.parent.parent.name), {}, {class: '', id: 'parent_category', name:''}
+              .category--box#children
+                = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.parent.id), {}, {class: 'select--wrap__box--select', id: 'child_category', name:''}
+              .category--box#grandchildren
+                = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.id), {}, {class: 'select--wrap__box--select', id: 'grandchild_category'}
           .brand
             .brand--title
               ブランド

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -21,7 +21,6 @@
                   %pre.dropzone-area__text
                     ドラッグ&ドロップ
                     またはクリックしてファイルをアップロード
-
       .products--name
         .products--name--title
           商品名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
         get 'get_category_children', defaults: { format: 'json' }
         get 'get_category_grandchildren', defaults: { format: 'json' }
       end
+      member do
+        get 'get_category_children', defaults: { format: 'json' }
+        get 'get_category_grandchildren', defaults: { format: 'json' }
+      end
   end
 
   resources :confirmations, only: :index

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2020_02_15_110401) do
     t.integer "favorite", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "buyer_id"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["user_id"], name: "index_products_on_user_id"
   end


### PR DESCRIPTION
# What
商品情報編集ページでカテゴリーのセレクトボックスに初期値としてデータベースに保存しているcategory_idから親、子、孫のカテゴリー名を表示し、編集を可能にする

# Why
ancestryを使用しているので、出品ページと同じコードでは表示できないため