### PR TITLE
パンくず修正

### DIFF
--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,7 +23,7 @@ end
 # end
 
 crumb :mypage do
-  link "マイページ", "/users/:id"
+  link "マイページ", user_path(current_user.id)
   parent :root
 end
 


### PR DESCRIPTION
#what 
パンくずマイページに遷移するパスがエラーが出ていたので、修正しました。
#why
link "マイページ", "/users/:id"
以下に変更
 link "マイページ", user_path(current_user.id)
 